### PR TITLE
[PATCH] - Sync .github to infra-engineering-template

### DIFF
--- a/.github/linters/zizmor.yml
+++ b/.github/linters/zizmor.yml
@@ -1,6 +1,3 @@
-ignore:
-  - ".github/workflows/braveart-infra.yml"
-
 rules:
   unpinned-uses:
     ignore:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -10,6 +10,13 @@ on:
       - "infra/**"
   workflow_dispatch:
     inputs:
+      env:
+        description: "Environment"
+        type: choice
+        default: prd
+        options:
+          - dev
+          - prd
       terraform_action:
         description: "Terraform Action"
         type: choice
@@ -26,9 +33,9 @@ permissions:
 jobs:
   # Plan, apply, or destroy Terraform infrastructure
   terraform:
-    name: "Terraform ${{ inputs.terraform_action || 'plan' }} (prd)"
+    name: "Terraform ${{ inputs.terraform_action || 'plan' }} (${{ inputs.env || 'prd' }})"
     runs-on: ubuntu-latest
-    environment: prd
+    environment: ${{ inputs.env || 'prd' }}
     env:
       ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -47,7 +54,7 @@ jobs:
       - name: "Ensure State Container"
         uses: ./.github/actions/ensure-tfstate-container
         with:
-          storage_account_name: sttfsplatformprduks01
+          storage_account_name: sttfsplatform${{ inputs.env || 'prd' }}uks01
           container_name: ${{ github.event.repository.name }}
           azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
           azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
@@ -55,41 +62,48 @@ jobs:
 
       - name: "Terraform Init"
         env:
+          TF_ENV: ${{ inputs.env || 'prd' }}
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
           terraform -chdir=infra init \
-            -backend-config="resource_group_name=rg-tfs-platform-prd-uks-01" \
-            -backend-config="storage_account_name=sttfsplatformprduks01" \
+            -backend-config="resource_group_name=rg-tfs-platform-$TF_ENV-uks-01" \
+            -backend-config="storage_account_name=sttfsplatform${TF_ENV}uks01" \
             -backend-config="container_name=$REPO_NAME" \
             -backend-config="key=terraform.tfstate" \
             -backend-config="subscription_id=${{ secrets.AZURE_PLATFORM_SUBSCRIPTION_ID }}"
 
       - name: "Terraform Plan"
         if: inputs.terraform_action == 'plan' || inputs.terraform_action == ''
+        env:
+          TF_ENV: ${{ inputs.env || 'prd' }}
         run: |
           terraform -chdir=infra plan \
             -var-file="vars/globals.tfvars" \
-            -var-file="vars/prd.tfvars"
+            -var-file="vars/$TF_ENV.tfvars"
 
       - name: "Terraform Apply"
         if: inputs.terraform_action == 'apply'
+        env:
+          TF_ENV: ${{ inputs.env || 'prd' }}
         run: |
           terraform -chdir=infra apply -auto-approve \
             -var-file="vars/globals.tfvars" \
-            -var-file="vars/prd.tfvars"
+            -var-file="vars/$TF_ENV.tfvars"
 
       - name: "Terraform Destroy"
         if: inputs.terraform_action == 'destroy'
+        env:
+          TF_ENV: ${{ inputs.env || 'prd' }}
         run: |
           terraform -chdir=infra destroy -auto-approve \
             -var-file="vars/globals.tfvars" \
-            -var-file="vars/prd.tfvars"
+            -var-file="vars/$TF_ENV.tfvars"
 
       - name: "Break State Lease"
         if: always()
         uses: ./.github/actions/break-tfstate-lease
         with:
-          storage_account_name: sttfsplatformprduks01
+          storage_account_name: sttfsplatform${{ inputs.env || 'prd' }}uks01
           container_name: ${{ github.event.repository.name }}
           azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
           azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Changes
- Added `env` input to terraform workflow dispatch (dev/prd, default prd)
- Made environment, storage account names, and var-file paths dynamic via `${{ inputs.env || 'prd' }}`
- Added `TF_ENV` env var to Init, Plan, Apply, and Destroy steps
- Removed stale `zizmor.yml` ignore entry for non-existent `braveart-infra.yml`