### PR TITLE
[PATCH] - Add artwork caching and checkout hardening

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -615,19 +615,6 @@ img {
   position: relative;
 }
 
-/* Tiny ornamental dot above plaque */
-.artwork__plaque::before {
-  content: "\2666";
-  position: absolute;
-  top: -0.5em;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: 0.5rem;
-  color: var(--gold);
-  opacity: 0.4;
-  background: var(--bg-deep);
-  padding: 0 0.5rem;
-}
 
 .artwork__title {
   font-family: "Cormorant Garamond", Georgia, serif;
@@ -848,18 +835,6 @@ img {
   position: relative;
 }
 
-.footer::before {
-  content: "\2666";
-  position: absolute;
-  top: -0.45em;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: 0.55rem;
-  color: var(--gold);
-  opacity: 0.4;
-  background: var(--bg-deep);
-  padding: 0 1rem;
-}
 
 .footer--floating {
   position: fixed;

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -409,6 +409,10 @@ img {
   animation: salon-fade-in 1s 0.9s ease forwards;
 }
 
+.salon-header .ornament {
+  opacity: 1;
+}
+
 .hero__note {
   font-family: "EB Garamond", Georgia, serif;
   font-size: 1.15rem;
@@ -614,7 +618,6 @@ img {
   border-top: 1px solid var(--border-gold);
   position: relative;
 }
-
 
 .artwork__title {
   font-family: "Cormorant Garamond", Georgia, serif;
@@ -834,7 +837,6 @@ img {
   margin-top: 3rem;
   position: relative;
 }
-
 
 .footer--floating {
   position: fixed;

--- a/frontend/gallery.html
+++ b/frontend/gallery.html
@@ -4,12 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>The Collection &mdash; Buffy Braveart Gallery</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;1,300;1,400&family=EB+Garamond:ital,wght@0,400;0,500;1,400&display=swap"
-      rel="stylesheet"
-    />
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,12 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Buffy Braveart Gallery</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;1,300;1,400&family=EB+Garamond:ital,wght@0,400;0,500;1,400&display=swap"
-      rel="stylesheet"
-    />
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body>

--- a/frontend/js/gallery.js
+++ b/frontend/js/gallery.js
@@ -114,10 +114,29 @@
     });
   }
 
-  fetch("/api/artworks")
-    .then((res) => {
-      return res.json();
-    })
+  var CACHE_KEY = "braveart_artworks";
+  var CACHE_TTL = 5 * 60 * 1000;
+
+  function getCached() {
+    try {
+      var entry = JSON.parse(sessionStorage.getItem(CACHE_KEY));
+      if (entry && Date.now() - entry.ts < CACHE_TTL) return entry.data;
+    } catch (_) {}
+    return null;
+  }
+
+  function setCached(data) {
+    try {
+      sessionStorage.setItem(CACHE_KEY, JSON.stringify({ ts: Date.now(), data: data }));
+    } catch (_) {}
+  }
+
+  var cached = getCached();
+  var artworkPromise = cached
+    ? Promise.resolve(cached)
+    : fetch("/api/artworks").then((res) => res.json()).then((data) => { setCached(data); return data; });
+
+  artworkPromise
     .then((artworks) => {
       var empty;
       loadingEl.remove();

--- a/frontend/js/gallery.js
+++ b/frontend/js/gallery.js
@@ -127,14 +127,22 @@
 
   function setCached(data) {
     try {
-      sessionStorage.setItem(CACHE_KEY, JSON.stringify({ ts: Date.now(), data: data }));
+      sessionStorage.setItem(
+        CACHE_KEY,
+        JSON.stringify({ ts: Date.now(), data: data }),
+      );
     } catch (_) {}
   }
 
   var cached = getCached();
   var artworkPromise = cached
     ? Promise.resolve(cached)
-    : fetch("/api/artworks").then((res) => res.json()).then((data) => { setCached(data); return data; });
+    : fetch("/api/artworks")
+        .then((res) => res.json())
+        .then((data) => {
+          setCached(data);
+          return data;
+        });
 
   artworkPromise
     .then((artworks) => {

--- a/frontend/js/gallery.js
+++ b/frontend/js/gallery.js
@@ -118,10 +118,13 @@
   var CACHE_TTL = 5 * 60 * 1000;
 
   function getCached() {
+    var entry;
     try {
-      var entry = JSON.parse(sessionStorage.getItem(CACHE_KEY));
+      entry = JSON.parse(sessionStorage.getItem(CACHE_KEY));
       if (entry && Date.now() - entry.ts < CACHE_TTL) return entry.data;
-    } catch (_) {}
+    } catch (e) {
+      void e;
+    }
     return null;
   }
 
@@ -131,7 +134,9 @@
         CACHE_KEY,
         JSON.stringify({ ts: Date.now(), data: data }),
       );
-    } catch (_) {}
+    } catch (e) {
+      void e;
+    }
   }
 
   var cached = getCached();

--- a/frontend/js/gallery.js
+++ b/frontend/js/gallery.js
@@ -69,7 +69,7 @@
         })
         .then((data) => {
           if (data.url) {
-            window.location.href = data.url;
+            window.open(data.url, "_blank");
             buyBtn.disabled = false;
             buyBtn.textContent = "Purchase";
           } else {

--- a/frontend/staticwebapp.config.json
+++ b/frontend/staticwebapp.config.json
@@ -8,6 +8,6 @@
   "globalHeaders": {
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
-    "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://files.stripe.com; connect-src 'self'; frame-src https://checkout.stripe.com"
+    "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https://files.stripe.com data:; connect-src 'self'; frame-src https://checkout.stripe.com"
   }
 }

--- a/frontend/staticwebapp.config.json
+++ b/frontend/staticwebapp.config.json
@@ -8,6 +8,6 @@
   "globalHeaders": {
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
-    "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https://files.stripe.com data:; connect-src 'self'; frame-src https://checkout.stripe.com"
+    "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https://files.stripe.com data:; connect-src 'self'; frame-src https://checkout.stripe.com"
   }
 }

--- a/functions/src/functions/artworkCache.js
+++ b/functions/src/functions/artworkCache.js
@@ -1,0 +1,41 @@
+const Stripe = require("stripe");
+
+let cachedArtworks = null;
+let cacheExpiry = 0;
+const CACHE_TTL = 5 * 60 * 1000;
+
+async function getCachedArtworks() {
+  if (cachedArtworks && Date.now() < cacheExpiry) {
+    return cachedArtworks;
+  }
+
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+
+  const products = await stripe.products.list({
+    active: true,
+    expand: ["data.default_price"],
+  });
+
+  const artworks = products.data
+    .filter((p) => p.default_price?.unit_amount)
+    .map((p) => ({
+      id: p.id,
+      priceId: p.default_price.id,
+      name: p.name,
+      description: p.description,
+      price: p.default_price.unit_amount,
+      imageUrl:
+        p.images.length > 0
+          ? p.images[0].startsWith("http")
+            ? p.images[0]
+            : `https://files.stripe.com/links/${p.images[0]}`
+          : null,
+    }));
+
+  cachedArtworks = artworks;
+  cacheExpiry = Date.now() + CACHE_TTL;
+
+  return artworks;
+}
+
+module.exports = { getCachedArtworks };

--- a/functions/src/functions/checkout.js
+++ b/functions/src/functions/checkout.js
@@ -1,17 +1,48 @@
 const { app } = require("@azure/functions");
 const Stripe = require("stripe");
+const { getCachedArtworks } = require("./artworkCache");
+
+// Rate limit: 5 checkout attempts per IP per minute
+const ipHits = new Map();
+const RATE_LIMIT = 5;
+const RATE_WINDOW_MS = 60 * 1000;
+
+function isRateLimited(ip) {
+  const now = Date.now();
+  const hits = (ipHits.get(ip) ?? []).filter((t) => now - t < RATE_WINDOW_MS);
+  if (hits.length >= RATE_LIMIT) return true;
+  ipHits.set(ip, [...hits, now]);
+  return false;
+}
 
 app.http("checkout", {
   methods: ["POST"],
   authLevel: "anonymous",
   route: "checkout",
   handler: async (request) => {
+    const ip = request.headers.get("x-forwarded-for") ?? "unknown";
+    if (isRateLimited(ip)) {
+      return {
+        status: 429,
+        jsonBody: { error: "Too many requests" },
+      };
+    }
+
     const body = await request.json();
 
     if (!body.priceId) {
       return {
         status: 400,
         jsonBody: { error: "priceId is required" },
+      };
+    }
+
+    const artworks = await getCachedArtworks();
+    const validPriceIds = new Set(artworks.map((a) => a.priceId));
+    if (!validPriceIds.has(body.priceId)) {
+      return {
+        status: 400,
+        jsonBody: { error: "Invalid priceId" },
       };
     }
 

--- a/functions/src/functions/getArtworks.js
+++ b/functions/src/functions/getArtworks.js
@@ -1,11 +1,19 @@
 const { app } = require("@azure/functions");
 const Stripe = require("stripe");
 
+let cachedArtworks = null;
+let cacheExpiry = 0;
+const CACHE_TTL = 5 * 60 * 1000;
+
 app.http("getArtworks", {
   methods: ["GET"],
   authLevel: "anonymous",
   route: "artworks",
   handler: async () => {
+    if (cachedArtworks && Date.now() < cacheExpiry) {
+      return { jsonBody: cachedArtworks };
+    }
+
     const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
     const products = await stripe.products.list({
@@ -27,6 +35,9 @@ app.http("getArtworks", {
               : `https://files.stripe.com/links/${p.images[0]}`)
           : null,
       }));
+
+    cachedArtworks = artworks;
+    cacheExpiry = Date.now() + CACHE_TTL;
 
     return {
       jsonBody: artworks,

--- a/functions/src/functions/getArtworks.js
+++ b/functions/src/functions/getArtworks.js
@@ -1,46 +1,12 @@
 const { app } = require("@azure/functions");
-const Stripe = require("stripe");
-
-let cachedArtworks = null;
-let cacheExpiry = 0;
-const CACHE_TTL = 5 * 60 * 1000;
+const { getCachedArtworks } = require("./artworkCache");
 
 app.http("getArtworks", {
   methods: ["GET"],
   authLevel: "anonymous",
   route: "artworks",
   handler: async () => {
-    if (cachedArtworks && Date.now() < cacheExpiry) {
-      return { jsonBody: cachedArtworks };
-    }
-
-    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
-
-    const products = await stripe.products.list({
-      active: true,
-      expand: ["data.default_price"],
-    });
-
-    const artworks = products.data
-      .filter((p) => p.default_price?.unit_amount)
-      .map((p) => ({
-        id: p.id,
-        priceId: p.default_price.id,
-        name: p.name,
-        description: p.description,
-        price: p.default_price.unit_amount,
-        imageUrl: p.images.length > 0
-          ? (p.images[0].startsWith("http")
-              ? p.images[0]
-              : `https://files.stripe.com/links/${p.images[0]}`)
-          : null,
-      }));
-
-    cachedArtworks = artworks;
-    cacheExpiry = Date.now() + CACHE_TTL;
-
-    return {
-      jsonBody: artworks,
-    };
+    const artworks = await getCachedArtworks();
+    return { jsonBody: artworks };
   },
 });

--- a/functions/src/functions/getArtworks.js
+++ b/functions/src/functions/getArtworks.js
@@ -21,7 +21,11 @@ app.http("getArtworks", {
         name: p.name,
         description: p.description,
         price: p.default_price.unit_amount,
-        imageUrl: p.images.length > 0 ? p.images[0] : null,
+        imageUrl: p.images.length > 0
+          ? (p.images[0].startsWith("http")
+              ? p.images[0]
+              : `https://files.stripe.com/links/${p.images[0]}`)
+          : null,
       }));
 
     return {


### PR DESCRIPTION
## Changes
- Add server-side in-memory artwork cache (5 min TTL) via shared `artworkCache.js` module
- Add client-side sessionStorage cache (5 min TTL) in gallery.js to skip redundant API calls
- Add rate limiting to checkout endpoint (5 requests/IP/minute)
- Validate priceId against cached artwork catalogue before creating Stripe session
- Open Stripe Checkout in new tab instead of redirecting current page
- Remove Google Fonts preconnect links from HTML pages
- Remove diamond ornaments from artwork plaque and footer
- Fix gallery header ornament opacity
- Allow `data:` image sources in CSP for Stripe image handling