### PR TITLE
[PATCH] - Fix mobile purchase redirect

### DIFF
--- a/frontend/gallery.html
+++ b/frontend/gallery.html
@@ -24,6 +24,6 @@
 
     <footer class="footer">&copy; 2026 Buffy Braveart Gallery</footer>
 
-    <script src="js/gallery.js?v=3"></script>
+    <script src="js/gallery.js?v=4"></script>
   </body>
 </html>

--- a/frontend/js/gallery.js
+++ b/frontend/js/gallery.js
@@ -51,6 +51,7 @@
     plaque.appendChild(price);
 
     var buyBtn = document.createElement("button");
+    buyBtn.type = "button";
     buyBtn.className = "artwork__buy";
     buyBtn.textContent = "Purchase";
     buyBtn.addEventListener("click", () => {
@@ -77,9 +78,7 @@
         })
         .then((data) => {
           if (data.url) {
-            window.open(data.url, "_blank");
-            buyBtn.disabled = false;
-            buyBtn.textContent = "Purchase";
+            window.location.assign(data.url);
           } else {
             throw new Error(data.error || "Checkout failed");
           }


### PR DESCRIPTION
**What does this PR change?**
Updates the gallery purchase flow to redirect the current page to the checkout URL instead of opening the checkout in a new tab/window. Also bumps the gallery script cache version and explicitly marks generated purchase buttons as `type="button"`.

**Why?**
Mobile browsers commonly block `window.open` calls after an asynchronous checkout request because they are no longer treated as part of the original user tap. Redirecting the current page avoids popup blocking and sends mobile users to the payment screen reliably.

**Related issue**
Closes #16

**Checklist**
- [ ] No functional behaviour changed
- [x] No secrets or credentials included