### PR TITLE
[PATCH] - Move pipelines to platform Key Vault and new state backend

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/swa.yml
+++ b/.github/workflows/swa.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Azure login
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Fetch SWA deployment token
         id: swa-token

--- a/.github/workflows/swa.yml
+++ b/.github/workflows/swa.yml
@@ -29,6 +29,8 @@ jobs:
     environment: ${{ inputs.environment || 'prd' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/.github/workflows/swa.yml
+++ b/.github/workflows/swa.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || 'prd' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
 
@@ -39,7 +39,7 @@ jobs:
         working-directory: functions
 
       - name: Azure login
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -56,7 +56,7 @@ jobs:
           echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
 
       - name: Deploy Static Web App
-        uses: azure/static-web-apps-deploy@v1
+        uses: azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1.0.0
         with:
           azure_static_web_apps_api_token: ${{ steps.swa-token.outputs.token }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 zizmor: ignore[artipacked]
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4 # zizmor: ignore[artipacked]
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -43,7 +43,7 @@ jobs:
       ARM_USE_OIDC: true
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -37,13 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.env || 'prd' }}
     env:
-      ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+      ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
       ARM_USE_OIDC: true
-      TF_VAR_yoco_secret_key: ${{ secrets.YOCO_SECRET_KEY }}
-      TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -56,11 +53,21 @@ jobs:
       - name: "Ensure State Container"
         uses: ./.github/actions/ensure-tfstate-container
         with:
-          storage_account_name: sttfsplatform${{ inputs.env || 'prd' }}uks01
+          storage_account_name: stplatform${{ inputs.env || 'prd' }}uks02
           container_name: ${{ github.event.repository.name }}
-          azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
-          azure_subscription_id: ${{ secrets.AZURE_PLATFORM_SUBSCRIPTION_ID }}
+          azure_client_id: ${{ vars.AZURE_CLIENT_ID }}
+          azure_tenant_id: ${{ vars.AZURE_TENANT_ID }}
+          azure_subscription_id: ${{ vars.AZURE_PLATFORM_SUBSCRIPTION_ID }}
+
+      - name: "Fetch Secrets From Key Vault"
+        uses: skyhaven-ltd/pipeline-engineering-github-actions/actions/keyvault-secrets@6cfa143b42ff464e4101d69c09945db9fac369e5 # v2.0.0
+        with:
+          keyvault_name: kv-platform-${{ inputs.env || 'prd' }}-uks-02
+          secrets: |
+            TF_VAR_yoco_secret_key=braveart-yoco-secret-key
+            TF_VAR_cloudflare_api_token=cloudflare-api-token
+            TF_VAR_cloudflare_account_id=cloudflare-account-id
+          login: "false"
 
       - name: "Terraform Init"
         env:
@@ -68,11 +75,11 @@ jobs:
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
           terraform -chdir=infra init \
-            -backend-config="resource_group_name=rg-tfs-platform-$TF_ENV-uks-01" \
-            -backend-config="storage_account_name=sttfsplatform${TF_ENV}uks01" \
+            -backend-config="resource_group_name=rg-platform-$TF_ENV-uks-01" \
+            -backend-config="storage_account_name=stplatform${TF_ENV}uks02" \
             -backend-config="container_name=$REPO_NAME" \
             -backend-config="key=terraform.tfstate" \
-            -backend-config="subscription_id=${{ secrets.AZURE_PLATFORM_SUBSCRIPTION_ID }}"
+            -backend-config="subscription_id=${{ vars.AZURE_PLATFORM_SUBSCRIPTION_ID }}"
 
       - name: "Terraform Plan"
         if: inputs.terraform_action == 'plan' || inputs.terraform_action == ''
@@ -105,8 +112,8 @@ jobs:
         if: always()
         uses: ./.github/actions/break-tfstate-lease
         with:
-          storage_account_name: sttfsplatform${{ inputs.env || 'prd' }}uks01
+          storage_account_name: stplatform${{ inputs.env || 'prd' }}uks02
           container_name: ${{ github.event.repository.name }}
-          azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
-          azure_subscription_id: ${{ secrets.AZURE_PLATFORM_SUBSCRIPTION_ID }}
+          azure_client_id: ${{ vars.AZURE_CLIENT_ID }}
+          azure_tenant_id: ${{ vars.AZURE_TENANT_ID }}
+          azure_subscription_id: ${{ vars.AZURE_PLATFORM_SUBSCRIPTION_ID }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -73,13 +73,14 @@ jobs:
         env:
           TF_ENV: ${{ inputs.env || 'prd' }}
           REPO_NAME: ${{ github.event.repository.name }}
+          PLATFORM_SUBSCRIPTION_ID: ${{ vars.AZURE_PLATFORM_SUBSCRIPTION_ID }}
         run: |
           terraform -chdir=infra init \
             -backend-config="resource_group_name=rg-platform-$TF_ENV-uks-01" \
             -backend-config="storage_account_name=stplatform${TF_ENV}uks02" \
             -backend-config="container_name=$REPO_NAME" \
             -backend-config="key=terraform.tfstate" \
-            -backend-config="subscription_id=${{ vars.AZURE_PLATFORM_SUBSCRIPTION_ID }}"
+            -backend-config="subscription_id=$PLATFORM_SUBSCRIPTION_ID"
 
       - name: "Terraform Plan"
         if: inputs.terraform_action == 'plan' || inputs.terraform_action == ''


### PR DESCRIPTION
**What does this pull request change?**
Migrates this repo's pipelines to the consolidated platform layout: Azure OIDC login now uses the `AZURE_*` GitHub environment **variables**, sensitive values are fetched from the platform Key Vault (`kv-platform-<env>-uks-02`) via the shared `keyvault-secrets` action (pinned v2.0.0), and the Terraform state backend moves to `rg-platform-<env>-uks-01` / `stplatform<env>uks02`. Key Vault fetches: yoco (braveart-yoco-secret-key) + shared Cloudflare pair.

**Why?**
GitHub secrets are write-only; the platform Key Vaults are now the source of truth for workflow secrets. Part of the estate-wide migration (runbook: `infra-landingzone-platform/docs/keyvault-migration-runbook.md`).

**Related issue**
N/A

**Checklist**

- [ ] No functional behaviour changed
- [x] No secrets or credentials included