### PR TITLE
[MINOR] - Standardize application Key Vault secret names

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -20,6 +20,6 @@ jobs:
       environments: '["dev","prd"]'
       terraform_version: "1.15.3"
       tf_var_secrets: |
-        TF_VAR_yoco_secret_key=braveart-yoco-secret-key
-        TF_VAR_cloudflare_api_token=cloudflare-api-token
-        TF_VAR_cloudflare_account_id=cloudflare-account-id
+        TF_VAR_yoco_secret_key=app-braveart-yoco-secret-key
+        TF_VAR_cloudflare_api_token=platform-cloudflare-api-token
+        TF_VAR_cloudflare_account_id=platform-cloudflare-account-id

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -77,9 +77,9 @@ jobs:
         with:
           keyvault_name: kv-platform-${{ inputs.env || 'prd' }}-uks-02
           secrets: |
-            TF_VAR_yoco_secret_key=braveart-yoco-secret-key
-            TF_VAR_cloudflare_api_token=cloudflare-api-token
-            TF_VAR_cloudflare_account_id=cloudflare-account-id
+            TF_VAR_yoco_secret_key=app-braveart-yoco-secret-key
+            TF_VAR_cloudflare_api_token=platform-cloudflare-api-token
+            TF_VAR_cloudflare_account_id=platform-cloudflare-account-id
           login: "false"
 
       - name: "Terraform Init"


### PR DESCRIPTION
**What does this pull request change?**
Updates BraveArt's Yoco credential to `app-braveart-yoco-secret-key` and its shared Cloudflare references to the `platform-*` names. Existing secret values are unchanged.

**Why?**
Makes secret ownership and credential type clear and consistent across repositories.

**Related issue**
Related to skyhaven-ltd/infra-homelab-config#63

**Checklist**

- [x] No functional behaviour changed
- [x] No secrets or credentials included